### PR TITLE
Add support for iterating the headers

### DIFF
--- a/lib/http_client/jruby/response.rb
+++ b/lib/http_client/jruby/response.rb
@@ -28,6 +28,16 @@ module HTTP
     def [](header_name)
       @native_response.get_first_header(header_name).value
     end
+    
+    def to_hash
+      Hash[ @native_response.get_all_headers.map{ |h| [h.get_name, h.get_value] } ]
+    end
+    
+    def each
+      i = @native_response.get_all_headers.each do |h|
+        yield h.get_name, h.get_value
+      end
+    end
   end
 
   class Cookies

--- a/lib/http_client/jruby/response.rb
+++ b/lib/http_client/jruby/response.rb
@@ -34,7 +34,7 @@ module HTTP
     end
     
     def each
-      i = @native_response.get_all_headers.each do |h|
+      @native_response.get_all_headers.each do |h|
         yield h.get_name, h.get_value
       end
     end

--- a/test/http_client/test_server_headers.rb
+++ b/test/http_client/test_server_headers.rb
@@ -7,6 +7,29 @@ class ServerHeadersTest < Test::Unit::TestCase
 
     assert_equal("FooBar", response.headers["Test-Header"])
   end
+  
+  def test_response_headers_to_hash
+    get = HTTP::Get.new("/set_header")
+    response = @client.execute(get)
+    response_hash = response.headers.to_hash
+    assert_equal(response_hash["Test-Header"], "FooBar")
+    assert_equal(response_hash["Content-Length"], "0")
+  end
+  
+  def test_response_headers_iteration
+    get = HTTP::Get.new("/set_header")
+    response = @client.execute(get)
+    
+    headers = values = []
+    response.headers.each do |header, value|
+      headers << header; values << value
+    end
+    
+    assert headers.include? "Test-Header"
+    assert headers.include? "Content-Length"
+    assert values.include? "FooBar"
+    assert values.include? "0"
+  end
 
   def setup
     @client = HTTP::Client.new(:default_host => "http://localhost:8080")


### PR DESCRIPTION
Added two methods:  #to_hash and #each to the header class in the native Java client.

Needed them to be Faraday compilant.

Thanks!

-Aaron
