### PR TITLE
Support for multi-value headers, HEAD, OPTIONS & PATCH (for MRI) 

### DIFF
--- a/lib/http_client/jruby/client.rb
+++ b/lib/http_client/jruby/client.rb
@@ -12,6 +12,14 @@ module HTTP
     def get(params, options = {})
       read_response(Get.new(params, options))
     end
+    
+    def head(params, options = {})
+      read_response(Head.new(params, options))
+    end
+    
+    def options(params, options = {})
+      read_response(Options.new(params, options))
+    end
 
     def post(params, options = {})
       read_response(Post.new(params, options))

--- a/lib/http_client/jruby/methods.rb
+++ b/lib/http_client/jruby/methods.rb
@@ -67,6 +67,20 @@ module HTTP
     end
   end
 
+  class Head < Request
+    def create_native_request
+      query_string = URLEncodedUtils.format(@query_params, encoding)
+      HttpHead.new(create_uri(query_string))
+    end
+  end
+
+  class Options < Request
+    def create_native_request
+      query_string = URLEncodedUtils.format(@query_params, encoding)
+      HttpOptions.new(create_uri(query_string))
+    end
+  end
+
   class Delete < Request
     def create_native_request
       HttpDelete.new(create_uri)
@@ -81,6 +95,8 @@ module HTTP
 
   private
   HttpGet = org.apache.http.client.methods.HttpGet
+  HttpHead = org.apache.http.client.methods.HttpHead
+  HttpOptions = org.apache.http.client.methods.HttpOptions
   HttpPost = org.apache.http.client.methods.HttpPost
   HttpDelete = org.apache.http.client.methods.HttpDelete
   HttpPut = org.apache.http.client.methods.HttpPut

--- a/lib/http_client/jruby/response.rb
+++ b/lib/http_client/jruby/response.rb
@@ -29,6 +29,10 @@ module HTTP
       @native_response.get_headers(header_name).map{|h| h.get_value}.join(", ")
     end
     
+    def to_s
+      @native_response.get_all_headers.map(&:to_s).join("\n")
+    end
+    
     def to_hash
       hash = {}
       each do |name, value|

--- a/lib/http_client/jruby/response.rb
+++ b/lib/http_client/jruby/response.rb
@@ -42,7 +42,7 @@ module HTTP
     end
     
     def each
-      @native_response.get_all_headers.each do |h|
+      @native_response.header_iterator.each do |h|
         yield h.get_name, h.get_value
       end
     end

--- a/lib/http_client/jruby/response.rb
+++ b/lib/http_client/jruby/response.rb
@@ -26,7 +26,7 @@ module HTTP
     end
 
     def [](header_name)
-      @native_response.get_first_header(header_name).value
+      @native_response.get_headers(header_name).map{|h| h.get_value}.join(", ")
     end
     
     def to_hash

--- a/lib/http_client/jruby/response.rb
+++ b/lib/http_client/jruby/response.rb
@@ -30,7 +30,11 @@ module HTTP
     end
     
     def to_hash
-      Hash[ @native_response.get_all_headers.map{ |h| [h.get_name, h.get_value] } ]
+      hash = {}
+      each do |name, value|
+        hash[name] = hash[name] ? hash[name] + ", #{value}" : value
+      end
+      hash
     end
     
     def each

--- a/lib/http_client/jruby/response.rb
+++ b/lib/http_client/jruby/response.rb
@@ -9,7 +9,12 @@ module HTTP
     end
 
     def body
-      @body ||= EntityUtils.to_string(@native_response.entity)
+      # HTTP HEAD requests have no entity, nor any body
+      if @native_response.entity
+        @body ||= EntityUtils.to_string(@native_response.entity)
+      else
+        nil
+      end
     end
 
     def status_code

--- a/lib/http_client/mri/methods.rb
+++ b/lib/http_client/mri/methods.rb
@@ -59,6 +59,42 @@ module HTTP
       params_as_hash.map { |name, value| "#{URI.encode(name.to_s)}=#{URI.encode(value.to_s)}" }.join("&")
     end
   end
+  
+  class Head < Request
+    def create_request
+      host, port, path, query = parse_uri
+      head = Net::HTTP::Head.new("#{path}?#{query || to_query_string(@params)}")
+      [host, port, head]
+    end
+
+    def to_query_string(params_as_hash)
+      params_as_hash.map { |name, value| "#{URI.encode(name.to_s)}=#{URI.encode(value.to_s)}" }.join("&")
+    end
+  end
+  
+  class Options < Request
+    def create_request
+      host, port, path, query = parse_uri
+      options = Net::HTTP::Options.new("#{path}?#{query || to_query_string(@params)}")
+      [host, port, options]
+    end
+
+    def to_query_string(params_as_hash)
+      params_as_hash.map { |name, value| "#{URI.encode(name.to_s)}=#{URI.encode(value.to_s)}" }.join("&")
+    end
+  end
+
+  class Patch < Request
+    def create_request
+      host, port, path, query = parse_uri
+      patch = Net::HTTP::Patch.new("#{path}?#{query || to_query_string(@params)}")
+      [host, port, patch]
+    end
+
+    def to_query_string(params_as_hash)
+      params_as_hash.map { |name, value| "#{URI.encode(name.to_s)}=#{URI.encode(value.to_s)}" }.join("&")
+    end
+  end
 
   class Post < Request
     def create_request


### PR DESCRIPTION
Here's my latest.  I made a couple more changes to the headers to use the Apache lib's iterator, and be more RFC compliant.  JRuby-HTTPClient now passes all of the Faraday tests with the adapter I've just committed--except HTTP PATCH support for JRuby.

The HTTP PATCH command isn't supported by the Apache lib yet, so I've included support for to MRI, but not JRuby.

The HTTP OPTIONS command in the Apache lib doesn't support an entity for some reason... if anyone actually tries to use that.

One thing I haven't done (but thought about) is support for multi-part requests for file uploads and such....

-Aaron
